### PR TITLE
ci: add workflow for lint and typecheck on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Lint
+name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:
@@ -27,3 +27,4 @@ jobs:
           cache-dependency-path: "./yarn.lock"
       - run: yarn install
       - run: yarn lint
+      - run: yarn typecheck


### PR DESCRIPTION
## Summary
- run lint and typecheck in CI on main branch

## Testing
- `yarn lint`
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689712e602e8832c84327129b475d0e6