### PR TITLE
Add tests for common utilities

### DIFF
--- a/src/common/__tests__/format-util.test.ts
+++ b/src/common/__tests__/format-util.test.ts
@@ -1,0 +1,13 @@
+import { getFormatDate } from "../format-util";
+
+describe("getFormatDate", () => {
+  it("formats a date with zero-padded month and day", () => {
+    const formatted = getFormatDate(new Date(2025, 1, 3));
+    expect(formatted).toBe("2025-02-03");
+  });
+
+  it("supports double-digit months and days without extra zeroes", () => {
+    const formatted = getFormatDate(new Date(2025, 10, 23));
+    expect(formatted).toBe("2025-11-23");
+  });
+});

--- a/src/common/__tests__/globalFnFactory.test.ts
+++ b/src/common/__tests__/globalFnFactory.test.ts
@@ -1,0 +1,34 @@
+import {
+  AddTransactionCallback,
+  SelectedAssets,
+  getGlobalFn,
+} from "../globalFnFactory";
+
+describe("globalFnFactory helpers", () => {
+  afterEach(() => {
+    SelectedAssets.deleteFn();
+    AddTransactionCallback.deleteFn();
+  });
+
+  it("stores and retrieves callbacks with SelectedAssets", () => {
+    const handler = () => 42;
+    SelectedAssets.setFn(handler);
+
+    const stored = SelectedAssets.getFn();
+    expect(stored).toBe(handler);
+    expect(SelectedAssets.hasFn()).toBe(true);
+
+    SelectedAssets.deleteFn();
+    expect(SelectedAssets.getFn()).toBe(undefined);
+    expect(SelectedAssets.hasFn()).toBe(false);
+  });
+
+  it("allows retrieving callbacks via getGlobalFn", async () => {
+    const callback = async () => "done";
+    AddTransactionCallback.setFn(callback);
+
+    const lookedUp = getGlobalFn<typeof callback>("AddTransactionCallback");
+    expect(lookedUp).toBe(callback);
+    expect(await lookedUp?.()).toBe("done");
+  });
+});

--- a/src/common/__tests__/session-utils.test.ts
+++ b/src/common/__tests__/session-utils.test.ts
@@ -1,0 +1,19 @@
+import { createSession } from "../session-utils";
+
+const createTokenWithPayload = (payload: Record<string, unknown>) => {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.signature`;
+};
+
+describe("createSession", () => {
+  it("extracts the user id from the JWT subject", () => {
+    const token = createTokenWithPayload({ sub: "user-123" });
+    expect(createSession(token)).toEqual({ userId: "user-123", authToken: token });
+  });
+
+  it("works with tokens that include additional claims", () => {
+    const token = createTokenWithPayload({ sub: "user-456", role: "admin" });
+    expect(createSession(token)).toEqual({ userId: "user-456", authToken: token });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for the date formatting helper to verify padding behavior
- cover the global function factory helpers and session creation utility with focused tests

## Testing
- yarn test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d896233250832c8c1f354e8f97ca07