### PR TITLE
Add unit tests for currency and request utilities

### DIFF
--- a/src/common/__tests__/currency-util.test.ts
+++ b/src/common/__tests__/currency-util.test.ts
@@ -1,0 +1,40 @@
+type GetCurrencySymbol = typeof import("../currency-util").getCurrencySymbol;
+
+describe("getCurrencySymbol", () => {
+  let getCurrencySymbol: GetCurrencySymbol;
+
+  beforeAll(() => {
+    const currencyIconsPath = require.resolve("currency-icons");
+    require.cache[currencyIconsPath] = {
+      exports: {
+        USD: { symbol: "$" },
+        EUR: {},
+      },
+    };
+
+    const modulePath = require.resolve("../currency-util");
+    delete require.cache[modulePath];
+    ({ getCurrencySymbol } = require("../currency-util"));
+  });
+
+  afterAll(() => {
+    const currencyIconsPath = require.resolve("currency-icons");
+    delete require.cache[currencyIconsPath];
+
+    const modulePath = require.resolve("../currency-util");
+    delete require.cache[modulePath];
+  });
+
+  it("returns the Yuan symbol for CNY regardless of configured icons", () => {
+    expect(getCurrencySymbol("CNY")).toBe("¥");
+  });
+
+  it("returns the symbol provided by currency-icons when available", () => {
+    expect(getCurrencySymbol("USD")).toBe("$");
+  });
+
+  it("falls back to an empty string when a symbol is unavailable", () => {
+    expect(getCurrencySymbol("EUR")).toBe("");
+    expect(getCurrencySymbol("ABC")).toBe("");
+  });
+});

--- a/src/common/__tests__/request.test.ts
+++ b/src/common/__tests__/request.test.ts
@@ -1,0 +1,54 @@
+import { config } from "../../config";
+
+type HeadersType = typeof import("../request").headers;
+type GetEndpointType = typeof import("../request").getEndpoint;
+
+describe("request utilities", () => {
+  let headers: HeadersType;
+  let getEndpoint: GetEndpointType;
+  let restoreResolveFilename: (() => void) | undefined;
+
+  beforeAll(() => {
+    const Module = require("module");
+    const originalResolveFilename = Module._resolveFilename;
+    const configPath = require.resolve("../../config");
+    Module._resolveFilename = function patch(request, parent, isMain, options) {
+      if (request === "@/config") {
+        return configPath;
+      }
+      return originalResolveFilename.call(this, request, parent, isMain, options);
+    };
+    restoreResolveFilename = () => {
+      Module._resolveFilename = originalResolveFilename;
+    };
+
+    const constantsPath = require.resolve("expo-constants");
+    require.cache[constantsPath] = {
+      exports: { nativeAppVersion: "9.9.9" },
+    };
+
+    const modulePath = require.resolve("../request");
+    delete require.cache[modulePath];
+    ({ headers, getEndpoint } = require("../request"));
+  });
+
+  afterAll(() => {
+    const constantsPath = require.resolve("expo-constants");
+    delete require.cache[constantsPath];
+
+    const modulePath = require.resolve("../request");
+    delete require.cache[modulePath];
+
+    restoreResolveFilename?.();
+  });
+
+  it("includes the app id and version headers", () => {
+    expect(headers["x-app-id"]).toBe(config.project);
+    expect(headers["x-app-version"]).toBe("9.9.9");
+  });
+
+  it("combines the server URL with the provided path", () => {
+    expect(getEndpoint("api/data")).toBe(`${config.serverUrl}api/data`);
+    expect(getEndpoint("/users")).toBe(`${config.serverUrl}/users`);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for `getCurrencySymbol`, including the `CNY` override and fallback behavior
- verify request headers and endpoint assembly by faking the Expo constants module

## Testing
- yarn test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d897eed34c832cbfbd3a23c422f452