### PR TITLE
Add utility module unit tests

### DIFF
--- a/src/common/__tests__/api.test.ts
+++ b/src/common/__tests__/api.test.ts
@@ -1,0 +1,126 @@
+import { config } from "../../config";
+
+type ApiModule = typeof import("../api");
+
+describe("api client", () => {
+  let api: ApiModule["api"];
+  let restoreResolveFilename: (() => void) | undefined;
+  let originalFetch: typeof fetch | undefined;
+
+  const Module = require("module");
+
+  beforeAll(() => {
+    const originalResolveFilename = Module._resolveFilename;
+    const configPath = require.resolve("../../config");
+    const requestPath = require.resolve("../request");
+
+    Module._resolveFilename = function resolve(request: string, parent: any, isMain: boolean, options: any) {
+      if (request === "@/config") {
+        return configPath;
+      }
+      if (request === "@/common/request") {
+        return requestPath;
+      }
+      return originalResolveFilename.call(this, request, parent, isMain, options);
+    };
+
+    restoreResolveFilename = () => {
+      Module._resolveFilename = originalResolveFilename;
+    };
+
+    const constantsPath = require.resolve("expo-constants");
+    require.cache[constantsPath] = {
+      exports: { nativeAppVersion: "42.0.0" },
+    };
+
+    const modulePath = require.resolve("../api");
+    delete require.cache[modulePath];
+    ({ api } = require("../api"));
+  });
+
+  afterAll(() => {
+    const constantsPath = require.resolve("expo-constants");
+    delete require.cache[constantsPath];
+
+    const modulePath = require.resolve("../api");
+    delete require.cache[modulePath];
+
+    restoreResolveFilename?.();
+  });
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch!;
+  });
+
+  it("posts credentials to the sign-in endpoint", async () => {
+    const responsePayload = { ok: true, authToken: "token" };
+    const calls: Array<{ url: string; options: RequestInit | undefined }> = [];
+
+    global.fetch = (async (url: RequestInfo, options?: RequestInit) => {
+      calls.push({ url: url as string, options });
+      return {
+        json: async () => responsePayload,
+      } as any;
+    }) as typeof fetch;
+
+    const result = await api.signIn("user@example.com", "secret");
+
+    expect(result).toEqual(responsePayload);
+    expect(calls.length).toBe(1);
+    const [{ url, options }] = calls;
+    expect(url).toBe(`${config.serverUrl}api/sign-in/`);
+    expect(options?.method).toBe("POST");
+    const headers = options?.headers as Record<string, string> | undefined;
+    expect(headers?.["Content-Type"]).toBe("application/json");
+    expect(headers?.["x-app-id"]).toBe(config.project);
+    expect(headers?.["x-app-version"]).toBe("42.0.0");
+    expect(options?.body).toBe(
+      JSON.stringify({ email: "user@example.com", password: "secret" }),
+    );
+  });
+
+  it("sends sign-up requests with the supplied credentials", async () => {
+    const responsePayload = { ok: true, authToken: "signup" };
+    let capturedUrl = "";
+    let capturedBody: string | undefined;
+
+    global.fetch = (async (url: RequestInfo, options?: RequestInit) => {
+      capturedUrl = url as string;
+      capturedBody = options?.body as string | undefined;
+      return {
+        json: async () => responsePayload,
+      } as any;
+    }) as typeof fetch;
+
+    const result = await api.signUp("new@example.com", "hunter2");
+
+    expect(result).toEqual(responsePayload);
+    expect(capturedUrl).toBe(`${config.serverUrl}api/sign-up/`);
+    expect(capturedBody).toBe(
+      JSON.stringify({ email: "new@example.com", password: "hunter2" }),
+    );
+  });
+
+  it("requests password resets with the provided email", async () => {
+    const responsePayload = { ok: true };
+    const recordedBodies: string[] = [];
+
+    global.fetch = (async (_url: RequestInfo, options?: RequestInit) => {
+      recordedBodies.push(options?.body as string);
+      return {
+        json: async () => responsePayload,
+      } as any;
+    }) as typeof fetch;
+
+    const result = await api.forgotPassword("reset@example.com");
+
+    expect(result).toEqual(responsePayload);
+    expect(recordedBodies).toEqual([
+      JSON.stringify({ email: "reset@example.com" }),
+    ]);
+  });
+});

--- a/src/common/__tests__/utilities.test.ts
+++ b/src/common/__tests__/utilities.test.ts
@@ -1,0 +1,203 @@
+import path from "path";
+
+describe("utility modules", () => {
+  describe("currency-util", () => {
+    const currencyIconsPath = require.resolve("currency-icons");
+    const modulePath = require.resolve("../currency-util");
+    let originalCurrencyIcons: NodeModule | undefined;
+
+    beforeEach(() => {
+      originalCurrencyIcons = require.cache[currencyIconsPath];
+      require.cache[currencyIconsPath] = {
+        exports: {
+          __esModule: true,
+          default: {
+            USD: { symbol: "$" },
+            EUR: { symbol: "€" },
+          },
+        },
+      } as NodeModule;
+      delete require.cache[modulePath];
+    });
+
+    afterEach(() => {
+      delete require.cache[modulePath];
+      if (originalCurrencyIcons) {
+        require.cache[currencyIconsPath] = originalCurrencyIcons;
+      } else {
+        delete require.cache[currencyIconsPath];
+      }
+    });
+
+    it("returns the Yuan symbol explicitly", () => {
+      const { getCurrencySymbol } = require("../currency-util");
+      expect(getCurrencySymbol("CNY")).toBe("¥");
+    });
+
+    it("looks up symbols from the currency icon table", () => {
+      const { getCurrencySymbol } = require("../currency-util");
+      expect(getCurrencySymbol("EUR")).toBe("€");
+    });
+
+    it("falls back to an empty string when unknown", () => {
+      const { getCurrencySymbol } = require("../currency-util");
+      expect(getCurrencySymbol("ZZZ")).toBe("");
+    });
+  });
+
+  describe("format-util", () => {
+    it("formats dates using yyyy-mm-dd", () => {
+      const { getFormatDate } = require("../format-util");
+      const formatted = getFormatDate(new Date("2024-01-05T10:20:30Z"));
+      expect(formatted).toBe("2024-01-05");
+    });
+  });
+
+  describe("number-utils", () => {
+    it("keeps a single decimal place for numbers below one thousand", () => {
+      const { shortNumber } = require("../number-utils");
+      expect(shortNumber(12)).toBe("12.0");
+      expect(shortNumber("18.5")).toBe("18.5");
+    });
+
+    it("adds suffixes for large magnitudes", () => {
+      const { shortNumber } = require("../number-utils");
+      expect(shortNumber(1200)).toBe("1.2K");
+      expect(shortNumber(2500000)).toBe("2.5M");
+      expect(shortNumber(7500000000)).toBe("7.5B");
+    });
+
+    it("preserves sign and omits decimals for whole results", () => {
+      const { shortNumber } = require("../number-utils");
+      expect(shortNumber(-3000000)).toBe("-3M");
+    });
+
+    it("returns the original string when parsing fails", () => {
+      const { shortNumber } = require("../number-utils");
+      expect(shortNumber("not-a-number")).toBe("not-a-number");
+    });
+  });
+
+  describe("session-utils", () => {
+    const jwtDecodePath = require.resolve("jwt-decode");
+    const sessionUtilsPath = require.resolve("../session-utils");
+    let originalJwtDecode: NodeModule | undefined;
+
+    beforeEach(() => {
+      originalJwtDecode = require.cache[jwtDecodePath];
+      require.cache[jwtDecodePath] = {
+        exports: {
+          __esModule: true,
+          default: (token: string) => ({ sub: `${token}-subject` }),
+        },
+      } as NodeModule;
+      delete require.cache[sessionUtilsPath];
+    });
+
+    afterEach(() => {
+      delete require.cache[sessionUtilsPath];
+      if (originalJwtDecode) {
+        require.cache[jwtDecodePath] = originalJwtDecode;
+      } else {
+        delete require.cache[jwtDecodePath];
+      }
+    });
+
+    it("derives a session object from the JWT subject", () => {
+      const { createSession } = require("../session-utils");
+      const token = "abc.def";
+      const session = createSession(token);
+      expect(session).toEqual({ userId: `${token}-subject`, authToken: token });
+    });
+  });
+
+  describe("request helpers", () => {
+    const Module = require("module");
+    const configPath = path.resolve(__dirname, "../../config.ts");
+    let restoreResolve: (() => void) | undefined;
+    const constantsPath = require.resolve("expo-constants");
+    let originalConstants: NodeModule | undefined;
+
+    beforeAll(() => {
+      const originalResolve = Module._resolveFilename;
+      Module._resolveFilename = function patched(request: string, parent: any, isMain: boolean, options: any) {
+        if (request === "@/config") {
+          return configPath;
+        }
+        return originalResolve.call(this, request, parent, isMain, options);
+      };
+      restoreResolve = () => {
+        Module._resolveFilename = originalResolve;
+      };
+    });
+
+    afterAll(() => {
+      restoreResolve?.();
+    });
+
+    beforeEach(() => {
+      originalConstants = require.cache[constantsPath];
+      require.cache[constantsPath] = {
+        exports: {
+          default: { nativeAppVersion: "9.9.9" },
+          nativeAppVersion: "9.9.9",
+        },
+      } as NodeModule;
+      delete require.cache[require.resolve("../request")];
+    });
+
+    afterEach(() => {
+      delete require.cache[require.resolve("../request")];
+      if (originalConstants) {
+        require.cache[constantsPath] = originalConstants;
+      } else {
+        delete require.cache[constantsPath];
+      }
+    });
+
+    it("exposes default headers including the current app version", () => {
+      const { headers } = require("../request");
+      const { config } = require("../../config");
+      expect(headers["x-app-id"]).toBe(config.project);
+      expect(headers["x-app-version"]).toBe("9.9.9");
+    });
+
+    it("builds absolute endpoints from relative paths", () => {
+      const { getEndpoint } = require("../request");
+      const { config } = require("../../config");
+      expect(getEndpoint("api/test/")).toBe(`${config.serverUrl}api/test/`);
+    });
+  });
+
+  describe("global function factory", () => {
+    const factoryPath = require.resolve("../globalFnFactory");
+
+    afterEach(() => {
+      delete require.cache[factoryPath];
+    });
+
+    it("stores, retrieves, and deletes global callbacks", () => {
+      const {
+        SelectedAssets,
+        SelectedCurrency,
+        getGlobalFn,
+      } = require("../globalFnFactory");
+
+      const assetsFn = (value: string) => value.toUpperCase();
+      expect(SelectedAssets.hasFn()).toBe(false);
+
+      SelectedAssets.setFn(assetsFn);
+      expect(SelectedAssets.hasFn()).toBe(true);
+      expect(SelectedAssets.getFn()).toBe(assetsFn);
+      expect(getGlobalFn<typeof assetsFn>("SelectedAssets")).toBe(assetsFn);
+
+      const currencyFn = (value: string) => `currency:${value}`;
+      SelectedCurrency.setFn(currencyFn);
+      expect(getGlobalFn<typeof currencyFn>("SelectedCurrency")).toBe(currencyFn);
+
+      SelectedAssets.deleteFn();
+      expect(SelectedAssets.hasFn()).toBe(false);
+      expect(getGlobalFn("SelectedAssets")).toBe(undefined);
+    });
+  });
+});

--- a/src/common/apollo/__tests__/persistent-var.test.ts
+++ b/src/common/apollo/__tests__/persistent-var.test.ts
@@ -1,0 +1,123 @@
+import type { ReactiveVar } from "@apollo/client";
+
+describe("createPersistentVar", () => {
+  let createPersistentVar: typeof import("../persistent-var").createPersistentVar;
+  const apolloPath = require.resolve("@apollo/client");
+  const asyncStoragePath = require.resolve("@react-native-async-storage/async-storage");
+  let originalApolloModule: NodeModule | undefined;
+  let originalAsyncStorageModule: NodeModule | undefined;
+
+  type Listener<T> = (value: T) => void;
+
+  const makeVarFactory = () => {
+    return function makeVar<T>(initialValue: T) {
+      let currentValue = initialValue;
+      const listeners: Listener<T>[] = [];
+      const reactiveVar = ((...args: [T?]) => {
+        if (args.length === 0) {
+          return currentValue;
+        }
+        currentValue = args[0] as T;
+        listeners.slice().forEach((listener) => listener(currentValue));
+        return currentValue;
+      }) as ReactiveVar<T>;
+      reactiveVar.onNextChange = (listener: Listener<T>) => {
+        listeners.push(listener);
+      };
+      return reactiveVar;
+    };
+  };
+
+  const asyncStorageMock = {
+    getItem: async (_key: string) => null as string | null,
+    setItem: async (_key: string, _value: string) => {},
+  };
+
+  beforeEach(() => {
+    originalApolloModule = require.cache[apolloPath];
+    originalAsyncStorageModule = require.cache[asyncStoragePath];
+
+    asyncStorageMock.getItem = async (_key: string) => null;
+    asyncStorageMock.setItem = async (_key: string, _value: string) => {};
+
+    require.cache[apolloPath] = {
+      exports: { makeVar: makeVarFactory() },
+    } as NodeModule;
+    require.cache[asyncStoragePath] = {
+      exports: asyncStorageMock,
+    } as NodeModule;
+
+    const modulePath = require.resolve("../persistent-var");
+    delete require.cache[modulePath];
+    ({ createPersistentVar } = require("../persistent-var"));
+  });
+
+  afterEach(() => {
+    const modulePath = require.resolve("../persistent-var");
+    delete require.cache[modulePath];
+
+    if (originalApolloModule) {
+      require.cache[apolloPath] = originalApolloModule;
+    } else {
+      delete require.cache[apolloPath];
+    }
+
+    if (originalAsyncStorageModule) {
+      require.cache[asyncStoragePath] = originalAsyncStorageModule;
+    } else {
+      delete require.cache[asyncStoragePath];
+    }
+  });
+
+  it("loads a stored value and updates the reactive var", async () => {
+    const storedValue = JSON.stringify({ user: "alice" });
+    asyncStorageMock.getItem = async (key: string) =>
+      key === "session" ? storedValue : null;
+
+    const [sessionVar, loadSession] = createPersistentVar("session", {
+      user: "unknown",
+    });
+
+    expect(sessionVar()).toEqual({ user: "unknown" });
+    const loaded = await loadSession();
+    expect(loaded).toEqual({ user: "alice" });
+    expect(sessionVar()).toEqual({ user: "alice" });
+  });
+
+  it("persists changes whenever the reactive var updates", async () => {
+    const writes: Array<{ key: string; value: string }> = [];
+    asyncStorageMock.setItem = async (key: string, value: string) => {
+      writes.push({ key, value });
+    };
+
+    const [themeVar] = createPersistentVar("theme", "light");
+    themeVar("dark");
+    await Promise.resolve();
+
+    expect(writes).toEqual([{ key: "theme", value: JSON.stringify("dark") }]);
+  });
+
+  it("logs errors when storage access fails and returns null", async () => {
+    const errors: Array<{ message: string; args: unknown[] }> = [];
+    const originalError = console.error;
+    console.error = ((message?: any, ...rest: any[]) => {
+      errors.push({ message, args: rest });
+    }) as typeof console.error;
+
+    try {
+      asyncStorageMock.getItem = async () => {
+        throw new Error("boom");
+      };
+
+      const [, loadValue] = createPersistentVar("locale", "en");
+      const result = await loadValue();
+
+      expect(result).toBe(null);
+      expect(
+        errors.some((entry) => `${entry.message}`.includes("Failed to load locale")),
+      ).toBe(true);
+    } finally {
+      console.error = originalError;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage-oriented tests for the currency, date-formatting, number-formatting, and session utility helpers
- verify request helper headers and global function registry behavior to exercise additional src modules

## Testing
- node ./scripts/jest-lite-runner.js

------
https://chatgpt.com/codex/tasks/task_e_68dc34a5f420832c96503240a543d584